### PR TITLE
Update link to the Pixel Perfect Handbook

### DIFF
--- a/projects/milestones/mockups-models.md
+++ b/projects/milestones/mockups-models.md
@@ -41,7 +41,7 @@ We'll be using [Figma](https://www.figma.com/) (free for students) to record ske
 
 [Here's and a basic tutorial for figma](http://cs52.me/workshops/design).
 
-*Additional reading: There are many good design resources out there. Here's [one](http://cdn.ustwo.com/PPP/PP3.pdf) about pixel perfect design.*
+*Additional reading: There are many good design resources out there. Here's [one](https://www.ustwo.com/blog/the-pixel-perfect-precision-handbook) about pixel perfect design.*
 
 #### Record and Upload Sketches
 


### PR DESCRIPTION
The updated link goes to a page that links to versions of the handbook.  An alternative is linking directly to the PDF bypassing the iBook option.  The PDF link can be found at [https://downloads.ctfassets.net/gw5wr8vzz44g/2bMTFo4agkUgmsSgeu8uik/9d2d7e4ee7d655ca847a009329e20976/PP3.pdf](https://downloads.ctfassets.net/gw5wr8vzz44g/2bMTFo4agkUgmsSgeu8uik/9d2d7e4ee7d655ca847a009329e20976/PP3.pdf)